### PR TITLE
PIA-627: Fix invalid state when switching wg regions mid-connection

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/ui/connection/ConnectFragment.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/connection/ConnectFragment.java
@@ -97,10 +97,7 @@ public class ConnectFragment extends Fragment {
         VpnStateEvent event = EventBus.getDefault().getStickyEvent(VpnStateEvent.class);
         int lastStateResId = event.getLocalizedResId();
         if (lastStateResId != 0) {
-            if(lastStateResId == de.blinkt.openvpn.R.string.state_waitconnectretry)
-                tvStatus.setText(VpnStatus.getLastCleanLogMessage(tvStatus.getContext()));
-            else
-                tvStatus.setText(getString(lastStateResId).toUpperCase());
+            tvStatus.setText(getString(lastStateResId).toUpperCase());
         }
 
         ConnectionStatus status = event.getLevel();

--- a/app/src/main/java/com/privateinternetaccess/android/ui/superclasses/BaseActivity.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/superclasses/BaseActivity.java
@@ -398,37 +398,33 @@ public abstract class BaseActivity extends SwipeBackBaseActivity implements Netw
             int lastStateResId = event.getLocalizedResId();
             String text = connectionText.getText().toString();
             if (lastStateResId != 0) {
-                if (lastStateResId == de.blinkt.openvpn.R.string.state_waitconnectretry) {
-                    text = VpnStatus.getLastCleanLogMessage(this);
-                } else {
-                    switch (status) {
-                        case LEVEL_CONNECTED:
-                            PIAServer server =
-                                    PIAServerHandler.getInstance(this).getSelectedRegion(this, false);
-                            text = getString(R.string.state_connected) + ": " + server.getName();
-                            break;
-                        case LEVEL_NONETWORK:
-                            text = getString(R.string.failed_connect_status);
-                            break;
-                        case LEVEL_NOTCONNECTED:
-                        case LEVEL_VPNPAUSED:
-                        case LEVEL_CONNECTING_SERVER_REPLIED:
-                        case LEVEL_CONNECTING_NO_SERVER_REPLY_YET:
-                        case LEVEL_START:
-                        case LEVEL_AUTH_FAILED:
-                        case LEVEL_WAITING_FOR_USER_INPUT:
-                        case UNKNOWN_LEVEL:
-                            if (disconnectedSpecialCase) {
-                                text = this.getString(R.string.snooze_status);
-                                if (TrustedWifiUtils.isEnabledAndConnected(this)) {
-                                    text = getString(R.string.state_exiting) + ": " +
-                                            getString(R.string.trusted_wifi_singular);
-                                }
-                            } else {
-                                text = this.getString(lastStateResId);
+                switch (status) {
+                    case LEVEL_CONNECTED:
+                        PIAServer server =
+                                PIAServerHandler.getInstance(this).getSelectedRegion(this, false);
+                        text = getString(R.string.state_connected) + ": " + server.getName();
+                        break;
+                    case LEVEL_NONETWORK:
+                        text = getString(R.string.failed_connect_status);
+                        break;
+                    case LEVEL_NOTCONNECTED:
+                    case LEVEL_VPNPAUSED:
+                    case LEVEL_CONNECTING_SERVER_REPLIED:
+                    case LEVEL_CONNECTING_NO_SERVER_REPLY_YET:
+                    case LEVEL_START:
+                    case LEVEL_AUTH_FAILED:
+                    case LEVEL_WAITING_FOR_USER_INPUT:
+                    case UNKNOWN_LEVEL:
+                        if (disconnectedSpecialCase) {
+                            text = this.getString(R.string.snooze_status);
+                            if (TrustedWifiUtils.isEnabledAndConnected(this)) {
+                                text = getString(R.string.state_exiting) + ": " +
+                                        getString(R.string.trusted_wifi_singular);
                             }
-                            break;
-                    }
+                        } else {
+                            text = this.getString(lastStateResId);
+                        }
+                        break;
                 }
             }
 

--- a/app/src/main/java/com/privateinternetaccess/android/ui/tv/GraphActivity.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/tv/GraphActivity.java
@@ -77,10 +77,7 @@ public class GraphActivity extends BaseActivity {
         String connectionText = getString(R.string.state_exiting);
         int lastStateResId = vpnEvent.getLocalizedResId();
         if (lastStateResId != 0) {
-            if(lastStateResId == de.blinkt.openvpn.R.string.state_waitconnectretry)
-                connectionText = VpnStatus.getLastCleanLogMessage(getApplicationContext());
-            else
-                connectionText = getString(lastStateResId);
+            connectionText = getString(lastStateResId);
         }
 
         PIAServerHandler handler =  PIAServerHandler.getInstance(getApplicationContext());

--- a/app/src/main/java/com/privateinternetaccess/android/ui/widgets/WidgetBaseProvider.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/widgets/WidgetBaseProvider.java
@@ -206,10 +206,6 @@ public class WidgetBaseProvider extends AppWidgetProvider  {
                 // make sure that if the user isn't logged in go to the login screen.
                 if (!connecting) {
                     EventBus.getDefault().register(listener);
-
-                    VpnStatus.updateStateString("GEN_CONFIG", "", R.string.state_gen_config,
-                            ConnectionStatus.LEVEL_START);
-
                     launchVPN(context);
                 } else {
                     IVPN vpn = PIAFactory.getInstance().getVPN(context.getApplicationContext());

--- a/app/src/main/java/com/privateinternetaccess/android/ui/widgets/WidgetProvider.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/widgets/WidgetProvider.java
@@ -50,7 +50,7 @@ public class WidgetProvider extends WidgetBaseProvider {
         for (int i=0; i<N; i++) {
             int appWidgetId = appWidgetIds[i];
             AppWidgetProviderInfo info = appWidgetManager.getAppWidgetInfo(appWidgetId);
-            if(info != null) {
+            if (info != null) {
                 int resId = info.initialLayout;
 
                 RemoteViews views = new RemoteViews(context.getPackageName(), resId);

--- a/app/src/main/java/com/privateinternetaccess/android/wireguard/backend/GoBackend.java
+++ b/app/src/main/java/com/privateinternetaccess/android/wireguard/backend/GoBackend.java
@@ -638,21 +638,20 @@ public final class GoBackend implements Backend {
                         setState(endpoint, testTunnel, State.UP);
                     }
                     catch (Throwable e) {
-                        VpnStateEvent event = new VpnStateEvent(
-                                "CONNECT",
-                                "Wireguard Connect",
-                                R.string.failed_connect_status,
-                                ConnectionStatus.LEVEL_NONETWORK
-                        );
-                        EventBus.getDefault().postSticky(event);
-                        lastState = State.DOWN;
-                        isConnecting = false;
-
-                        PIANotifications.Companion.getSharedInstance().hideNotification(
-                                context,
-                                NOTIFICATION_CHANNEL_NEWSTATUS_ID.hashCode()
-                        );
                         e.printStackTrace();
+                        EventBus.getDefault().postSticky(
+                                new VpnStateEvent(
+                                        "CONNECT",
+                                        "Wireguard Connect",
+                                        R.string.failed_connect_status,
+                                        ConnectionStatus.LEVEL_NONETWORK
+                                )
+                        );
+                        try {
+                            disconnect();
+                        } catch (Throwable ex) {
+                            ex.printStackTrace();
+                        }
                     }
                 }
             });

--- a/app/src/main/res/values-b+ar/strings.xml
+++ b/app/src/main/res/values-b+ar/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">لا، شكرًا</string>
     <string name="read_more"><u>قراءة المزيد</u></string>
     <string name="state_gen_config">جارٍ إنشاء التكوين</string>
+    <string name="state_waitconnectretry">يتم الانتظار %s ثوان بين محاولات الاتصال</string>
     <string name="user_pw_invalid">اسم المستخدم/كلمة المرور غير صحيحة</string>
     <string name="replace_login_title">استبدال معلومات تسجيل الدخول</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+da/strings.xml
+++ b/app/src/main/res/values-b+da/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">nej tak</string>
     <string name="read_more"><u>Læs mere</u></string>
     <string name="state_gen_config">Genererer konfiguration</string>
+    <string name="state_waitconnectretry">Venter %s sekunder mellem forbindelsesforsøg</string>
     <string name="user_pw_invalid">Brugernavn eller kodeord ugyldigt</string>
     <string name="replace_login_title">Erstat log ind-information</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+de/strings.xml
+++ b/app/src/main/res/values-b+de/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">Nein danke</string>
     <string name="read_more"><u>Mehr erfahren</u></string>
     <string name="state_gen_config">Konfiguration wird erzeugt</string>
+    <string name="state_waitconnectretry">Zwischen Verbindungsversuchen %s Sekunden warten</string>
     <string name="user_pw_invalid">Benutzername/Passwort ungültig</string>
     <string name="replace_login_title">Anmeldeinformationen ersetzen</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+es-rMX/strings.xml
+++ b/app/src/main/res/values-b+es-rMX/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">no, gracias</string>
     <string name="read_more"><u>Más información</u></string>
     <string name="state_gen_config">Generando configuración</string>
+    <string name="state_waitconnectretry">Esperando %s segundos entre intentos de conexión</string>
     <string name="user_pw_invalid">Nombre de usuario o contraseña inválidas</string>
     <string name="replace_login_title">Remplazar la información de inicio de sesión</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">non merci</string>
     <string name="read_more"><u>Lire plus</u></string>
     <string name="state_gen_config">Génération de la configuration</string>
+    <string name="state_waitconnectretry">Attente de %s secondes entre les tentatives de connexion</string>
     <string name="user_pw_invalid">Nom d\'utilisateur/mot de passe invalide</string>
     <string name="replace_login_title">Remplacer les informations de connexion</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+it/strings.xml
+++ b/app/src/main/res/values-b+it/strings.xml
@@ -70,6 +70,7 @@ privateinternetaccess.com</string>
     <string name="no_thanks">no grazie</string>
     <string name="read_more"><u>Leggi di più</u></string>
     <string name="state_gen_config">Creando configurazione</string>
+    <string name="state_waitconnectretry">Attesa di %s secondi tra i tentativi di riconnessione</string>
     <string name="user_pw_invalid">Nome utente/password non validi</string>
     <string name="replace_login_title">Sostituisci dati d\'accesso</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+ja/strings.xml
+++ b/app/src/main/res/values-b+ja/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">いいえ、結構です</string>
     <string name="read_more"><u>詳細</u></string>
     <string name="state_gen_config">構成を生成中</string>
+    <string name="state_waitconnectretry">%s秒間隔で接続を待機</string>
     <string name="user_pw_invalid">ユーザー名/パスワードが無効です</string>
     <string name="replace_login_title">ログイン情報を置き換える</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+ko/strings.xml
+++ b/app/src/main/res/values-b+ko/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">아니요</string>
     <string name="read_more"><u>자세히 보기</u></string>
     <string name="state_gen_config">구성 생성 중</string>
+    <string name="state_waitconnectretry">연결 시도 사이에 %s초를 기다리는 중</string>
     <string name="user_pw_invalid">사용자 이름/비밀번호가 잘못됨</string>
     <string name="replace_login_title">로그인 정보 교체</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+nb/strings.xml
+++ b/app/src/main/res/values-b+nb/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">nei takk</string>
     <string name="read_more"><u>Les mer</u></string>
     <string name="state_gen_config">Genererer konfigurasjon</string>
+    <string name="state_waitconnectretry">Venter %s sekunder mellom tilkoblingsforsøk</string>
     <string name="user_pw_invalid">Ugyldig brukernavn/passord</string>
     <string name="replace_login_title">Erstatt påloggingsinformasjon</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+nl/strings.xml
+++ b/app/src/main/res/values-b+nl/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">nee, bedankt</string>
     <string name="read_more"><u> Meer lezen</u></string>
     <string name="state_gen_config">Configuratie genereren</string>
+    <string name="state_waitconnectretry">Wacht %s seconden en probeer opnieuw verbinding te maken</string>
     <string name="user_pw_invalid">Gebruikersnaam/wachtwoord ongeldig</string>
     <string name="replace_login_title">Inloginformatie vervangen</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+pl/strings.xml
+++ b/app/src/main/res/values-b+pl/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">nie, dziękuję</string>
     <string name="read_more"><u>Dowiedz się więcej</u></string>
     <string name="state_gen_config">Generowanie konfiguracji</string>
+    <string name="state_waitconnectretry">Oczekiwanie %s sekund między próbami połączenia</string>
     <string name="user_pw_invalid">Nieprawidłowa nazwa użytkownika/Hasło</string>
     <string name="replace_login_title">Zmień dane logowania</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+pt-rBR/strings.xml
+++ b/app/src/main/res/values-b+pt-rBR/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">não, obrigado</string>
     <string name="read_more"><u>Leia mais</u></string>
     <string name="state_gen_config">Gerando configuração</string>
+    <string name="state_waitconnectretry">Aguardando %s segundos entre tentativas de conexão</string>
     <string name="user_pw_invalid">Nome de usuário/senha inválida</string>
     <string name="replace_login_title">Substituir as informações de login</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+ru/strings.xml
+++ b/app/src/main/res/values-b+ru/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">Спасибо, не надо</string>
     <string name="read_more"><u>Подробнее</u></string>
     <string name="state_gen_config">Генерирование конфигурации...</string>
+    <string name="state_waitconnectretry">Ждем %s с между попытками подключения</string>
     <string name="user_pw_invalid">Неверное сочетание имени пользователя и пароля</string>
     <string name="replace_login_title">Заменить учетные данные</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+th/strings.xml
+++ b/app/src/main/res/values-b+th/strings.xml
@@ -70,6 +70,7 @@
     <string name="no_thanks">ไม่ล่ะ ขอบคุณ</string>
     <string name="read_more"><u>อ่านเพิ่มเติม</u></string>
     <string name="state_gen_config">กำลังสร้างการกำหนดค่า</string>
+    <string name="state_waitconnectretry">กำลังรอ %s วินาทีระหว่างความพยายามเชื่อมต่อ</string>
     <string name="user_pw_invalid">ชื่อผู้ใช้/รหัสผ่านไม่ถูกต้อง</string>
     <string name="replace_login_title">แทนที่ข้อมูลเข้าสู่ระบบ</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+tr/strings.xml
+++ b/app/src/main/res/values-b+tr/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">hayır teşekkürler</string>
     <string name="read_more"><u>Daha fazlasını okuyun</u></string>
     <string name="state_gen_config">Yapılandırma oluşturuluyor</string>
+    <string name="state_waitconnectretry">Bağlanma denemeleri arasında %s saniye bekleniyor</string>
     <string name="user_pw_invalid">Kullanıcı Adı/Şifre geçersiz</string>
     <string name="replace_login_title">Giriş bilgilerini değiştir</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+zh-rCN/strings.xml
+++ b/app/src/main/res/values-b+zh-rCN/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">不用，谢谢</string>
     <string name="read_more"><u>阅读更多</u></string>
     <string name="state_gen_config">正在生成配置</string>
+    <string name="state_waitconnectretry">正在等候%s秒后重试连接</string>
     <string name="user_pw_invalid">用户名/密码无效</string>
     <string name="replace_login_title">更换登录信息</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values-b+zh-rTW/strings.xml
+++ b/app/src/main/res/values-b+zh-rTW/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">不了，謝謝</string>
     <string name="read_more"><u>深入了解</u></string>
     <string name="state_gen_config">正在產生配置</string>
+    <string name="state_waitconnectretry">在嘗試連線之間等待 %s 秒</string>
     <string name="user_pw_invalid">使用者名稱／密碼不正確</string>
     <string name="replace_login_title">取代登入資料</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_thanks">no thanks</string>
     <string name="read_more"><u>Read more</u></string>
     <string name="state_gen_config">Generating configuration</string>
+    <string name="state_waitconnectretry">Waiting %s seconds between connection attempts</string>
     <string name="user_pw_invalid">Username/Password invalid</string>
     <string name="replace_login_title">Replace login information</string>
     <!-- Please keep the %1$s %2$s, this is a formattered text. %1$s %2$s are usernames.  -->


### PR DESCRIPTION
## Summary

- It fixes an issue where switching to a region mid-connection was leaving the initial connection alive, but the dashboard was showing disconnected. This is due to a partial teardown being done. Updated to re-use the disconnect logic.
- It fixes an issue where we were using the ovpn`VpnStatus.*` object on places with common logic for both protocols, which led to an eventual ANR when using wireguard.

## Sanity Tests

### Wireguard

- [x] Using Quick Connect. Start a connection to Region-A. Quickly change to Region-B. Confirm the connection to Region-A is interrupted.
- [x] Repeat the above multiple times. Confirm the application stays responsive and in the proper state.

### OpenVpn

- [x] Using Quick Connect. Start a connection to Region-A. Quickly change to Region-B. Confirm the connection to Region-A is interrupted.
- [x] Repeat the above multiple times. Confirm the application stays responsive and in the proper state.

## Smoke Tests

- [x] Login. Allow permissions. Confirm we reach the Dashboard successfully.
- [x] Using Wireguard. Connect to any region. Confirm we can connect successfully.
- [x] Using OpenVPN. Connect to any region. Confirm we can connect successfully.