### PR TITLE
PIA-658: extend sign in tests coverage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -238,6 +238,8 @@ android {
             debuggable true
             buildConfigField 'String', 'PIA_VALID_USERNAME', "\"" + System.getenv("PIA_VALID_USERNAME") + "\""
             buildConfigField 'String', 'PIA_VALID_PASSWORD', "\"" + System.getenv("PIA_VALID_PASSWORD") + "\""
+            buildConfigField 'String', 'PIA_INVALID_USERNAME', "\"${System.getenv("PIA_INVALID_USERNAME")}\""
+            buildConfigField 'String', 'PIA_INVALID_PASSWORD', "\"${System.getenv("PIA_INVALID_PASSWORD")}\""
             buildConfigField 'String', 'PIA_VALID_DIP_TOKEN', "\"" + System.getenv("PIA_VALID_DIP_TOKEN") + "\""
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ repositories {
 
 dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
+    implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
@@ -235,6 +236,9 @@ android {
         }
         debug {
             debuggable true
+            buildConfigField 'String', 'PIA_VALID_USERNAME', "\"" + System.getenv("PIA_VALID_USERNAME") + "\""
+            buildConfigField 'String', 'PIA_VALID_PASSWORD', "\"" + System.getenv("PIA_VALID_PASSWORD") + "\""
+            buildConfigField 'String', 'PIA_VALID_DIP_TOKEN', "\"" + System.getenv("PIA_VALID_DIP_TOKEN") + "\""
         }
     }
     ndkVersion '21.1.6352462'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -236,11 +236,11 @@ android {
         }
         debug {
             debuggable true
-            buildConfigField 'String', 'PIA_VALID_USERNAME', "\"" + System.getenv("PIA_VALID_USERNAME") + "\""
-            buildConfigField 'String', 'PIA_VALID_PASSWORD', "\"" + System.getenv("PIA_VALID_PASSWORD") + "\""
+            buildConfigField 'String', 'PIA_VALID_USERNAME', "\"${System.getenv("PIA_VALID_USERNAME")}\""
+            buildConfigField 'String', 'PIA_VALID_PASSWORD', "\"${System.getenv("PIA_VALID_PASSWORD")}\""
             buildConfigField 'String', 'PIA_INVALID_USERNAME', "\"${System.getenv("PIA_INVALID_USERNAME")}\""
             buildConfigField 'String', 'PIA_INVALID_PASSWORD', "\"${System.getenv("PIA_INVALID_PASSWORD")}\""
-            buildConfigField 'String', 'PIA_VALID_DIP_TOKEN', "\"" + System.getenv("PIA_VALID_DIP_TOKEN") + "\""
+            buildConfigField 'String', 'PIA_VALID_DIP_TOKEN', "\"${System.getenv("PIA_VALID_DIP_TOKEN")}\""
         }
     }
     ndkVersion '21.1.6352462'

--- a/app/src/androidTest/java/core/BaseUiAutomatorClass.kt
+++ b/app/src/androidTest/java/core/BaseUiAutomatorClass.kt
@@ -1,0 +1,32 @@
+package com.privateinternetaccess.android.core
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.junit.Before
+
+open class BaseUiAutomatorClass {
+
+    private lateinit var device: UiDevice
+    private lateinit var context: Context
+
+    private fun startApp(packageName: String, activityName: String? = null) {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = if (activityName == null) {
+            context.packageManager.getLaunchIntentForPackage(packageName)
+        } else {
+            Intent().setClassName(packageName, activityName)
+        }
+        intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) // Clear out any previous instances
+        context.startActivity(intent)
+    }
+
+    @Before
+    fun setUp() {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.pressHome()
+        startApp("com.privateinternetaccess.android")
+    }
+}

--- a/app/src/androidTest/java/core/BaseUiAutomatorClass.kt
+++ b/app/src/androidTest/java/core/BaseUiAutomatorClass.kt
@@ -29,4 +29,8 @@ open class BaseUiAutomatorClass {
         device.pressHome()
         startApp("com.privateinternetaccess.android")
     }
+
+    companion object {
+        const val defaultTimeOut = 5000L
+    }
 }

--- a/app/src/androidTest/java/helpers/ActionHelpers.kt
+++ b/app/src/androidTest/java/helpers/ActionHelpers.kt
@@ -1,0 +1,18 @@
+package com.privateinternetaccess.android.helpers
+
+import androidx.test.uiautomator.UiObject
+
+object ActionHelpers {
+
+    fun clickIfExists(primaryUiObject : UiObject, secondaryUiObj: UiObject? = null) {
+        if (primaryUiObject.exists()) {
+            (secondaryUiObj ?: primaryUiObject).click()
+        }
+    }
+
+    fun <T> inputTextInField(field: UiObject, data: T? = null) {
+        field.clearTextField()
+        field.click()
+        field.text = data?.toString() ?: ""
+    }
+}

--- a/app/src/androidTest/java/helpers/LocatorHelper.kt
+++ b/app/src/androidTest/java/helpers/LocatorHelper.kt
@@ -1,0 +1,15 @@
+package com.privateinternetaccess.android.helpers
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject
+import androidx.test.uiautomator.UiSelector
+
+object LocatorHelper {
+
+    private val device: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    fun findByResourceId(id: String, instance: Int = 0): UiObject {
+        return device.findObject(UiSelector().resourceId(id).instance(instance))
+    }
+}

--- a/app/src/androidTest/java/screens/objects/MainScreenPageObjects.kt
+++ b/app/src/androidTest/java/screens/objects/MainScreenPageObjects.kt
@@ -1,0 +1,9 @@
+package com.privateinternetaccess.android.screens.objects
+
+import com.privateinternetaccess.android.helpers.LocatorHelper
+
+class MainScreenPageObjects {
+
+    val connectButton = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/connection_background")
+
+}

--- a/app/src/androidTest/java/screens/objects/SignInPageObjects.kt
+++ b/app/src/androidTest/java/screens/objects/SignInPageObjects.kt
@@ -16,5 +16,7 @@ class SignInPageObjects {
 
     val loginWithReceipt = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/fragment_login_receipt")
 
+    val subscribeButton = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/subscribe")
+
     val noUsernameOrPasswordError = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/piaxEditTextError")
 }

--- a/app/src/androidTest/java/screens/objects/SignInPageObjects.kt
+++ b/app/src/androidTest/java/screens/objects/SignInPageObjects.kt
@@ -1,0 +1,20 @@
+package com.privateinternetaccess.android.screens.objects
+
+import com.privateinternetaccess.android.helpers.LocatorHelper
+
+class SignInPageObjects {
+
+    val notificationPrompt = LocatorHelper.findByResourceId("com.android.permissioncontroller:id/permission_message")
+    val allowNotifications = LocatorHelper.findByResourceId("com.android.permissioncontroller:id/permission_allow_button")
+    val denyNotifications = LocatorHelper.findByResourceId("com.android.permissioncontroller:id/permission_deny_button")
+    val reachLoginScreenButton = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/login")
+    val usernameField = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/piaxEditText")
+    val passwordField = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/piaxEditText", instance = 1)
+    val loginButton = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/fragment_login_button")
+    val vpnProfileOkButton = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/activity_vpn_permissions_button")
+    val androidOkButton = LocatorHelper.findByResourceId("android:id/button1")
+
+    val loginWithReceipt = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/fragment_login_receipt")
+
+    val noUsernameOrPasswordError = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/piaxEditTextError")
+}

--- a/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
+++ b/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
@@ -3,6 +3,7 @@ package com.privateinternetaccess.android.screens.steps
 import com.privateinternetaccess.android.helpers.ActionHelpers.clickIfExists
 import com.privateinternetaccess.android.helpers.ActionHelpers.inputTextInField
 import com.privateinternetaccess.android.screens.objects.SignInPageObjects
+import com.privateinternetaccess.android.core.BaseUiAutomatorClass.Companion.defaultTimeOut
 
 class SignInStepObjects {
 
@@ -13,7 +14,7 @@ class SignInStepObjects {
     }
 
     fun reachSignInScreen() {
-        signInPageObjects.reachLoginScreenButton.clickAndWaitForNewWindow(5000)
+        signInPageObjects.reachLoginScreenButton.clickAndWaitForNewWindow(defaultTimeOut)
     }
 
     fun enterUsername(username : String?) {
@@ -25,7 +26,7 @@ class SignInStepObjects {
     }
 
     fun clickOnLoginButton() {
-        signInPageObjects.loginButton.clickAndWaitForNewWindow(5000)
+        signInPageObjects.loginButton.clickAndWaitForNewWindow(defaultTimeOut)
     }
 
     fun allowVpnProfileCreation() {

--- a/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
+++ b/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
@@ -1,5 +1,6 @@
 package com.privateinternetaccess.android.screens.steps
 
+import com.privateinternetaccess.android.BuildConfig
 import com.privateinternetaccess.android.helpers.ActionHelpers.clickIfExists
 import com.privateinternetaccess.android.helpers.ActionHelpers.inputTextInField
 import com.privateinternetaccess.android.screens.objects.SignInPageObjects
@@ -17,11 +18,8 @@ class SignInStepObjects {
         signInPageObjects.reachLoginScreenButton.clickAndWaitForNewWindow(defaultTimeOut)
     }
 
-    fun enterUsername(username : String?) {
+    fun enterCredentials(username : String = BuildConfig.PIA_VALID_USERNAME, password : String = BuildConfig.PIA_VALID_PASSWORD) {
         inputTextInField(signInPageObjects.usernameField, username)
-    }
-
-    fun enterPassword(password : String?) {
         inputTextInField(signInPageObjects.passwordField, password)
     }
 

--- a/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
+++ b/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
@@ -1,0 +1,35 @@
+package com.privateinternetaccess.android.screens.steps
+
+import com.privateinternetaccess.android.helpers.ActionHelpers.clickIfExists
+import com.privateinternetaccess.android.helpers.ActionHelpers.inputTextInField
+import com.privateinternetaccess.android.screens.objects.SignInPageObjects
+
+class SignInStepObjects {
+
+    private val signInPageObjects = SignInPageObjects()
+
+    fun allowNotifications() {
+        clickIfExists(signInPageObjects.notificationPrompt, signInPageObjects.allowNotifications)
+    }
+
+    fun reachSignInScreen() {
+        signInPageObjects.reachLoginScreenButton.clickAndWaitForNewWindow(5000)
+    }
+
+    fun enterUsername(username : String?) {
+        inputTextInField(signInPageObjects.usernameField, username)
+    }
+
+    fun enterPassword(password : String?) {
+        inputTextInField(signInPageObjects.passwordField, password)
+    }
+
+    fun clickOnLoginButton() {
+        signInPageObjects.loginButton.clickAndWaitForNewWindow(5000)
+    }
+
+    fun allowVpnProfileCreation() {
+        clickIfExists(signInPageObjects.vpnProfileOkButton)
+        clickIfExists(signInPageObjects.androidOkButton)
+    }
+}

--- a/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
+++ b/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
@@ -18,7 +18,10 @@ class SignInStepObjects {
         signInPageObjects.reachLoginScreenButton.clickAndWaitForNewWindow(defaultTimeOut)
     }
 
-    fun enterCredentials(username : String = BuildConfig.PIA_VALID_USERNAME, password : String = BuildConfig.PIA_VALID_PASSWORD) {
+    fun enterCredentials(
+        username : String = BuildConfig.PIA_VALID_USERNAME, 
+        password : String = BuildConfig.PIA_VALID_PASSWORD
+    ) {
         inputTextInField(signInPageObjects.usernameField, username)
         inputTextInField(signInPageObjects.passwordField, password)
     }

--- a/app/src/androidTest/java/tests/SignInTests.kt
+++ b/app/src/androidTest/java/tests/SignInTests.kt
@@ -26,8 +26,8 @@ class SignInTests : BaseUiAutomatorClass() {
     fun incorrectCredentialsReturnToSplashScreen() {
         stepObjects.allowNotifications()
         stepObjects.reachSignInScreen()
-        stepObjects.enterUsername("PLACEHOLDER")
-        stepObjects.enterPassword("PLACEHOLDER")
+        stepObjects.enterUsername(BuildConfig.PIA_INVALID_USERNAME)
+        stepObjects.enterPassword(BuildConfig.PIA_INVALID_PASSWORD)
         stepObjects.clickOnLoginButton()
         assert(SignInPageObjects().reachLoginScreenButton.exists())
     }
@@ -39,4 +39,24 @@ class SignInTests : BaseUiAutomatorClass() {
         stepObjects.clickOnLoginButton()
         assert(SignInPageObjects().noUsernameOrPasswordError.exists())
     }
+
+    @Test
+    fun errorMessageIfNoPasswordProvided() {
+        stepObjects.allowNotifications()
+        stepObjects.reachSignInScreen()
+        stepObjects.enterUsername(BuildConfig.PIA_VALID_USERNAME)
+        stepObjects.clickOnLoginButton()
+        assert(SignInPageObjects().noUsernameOrPasswordError.exists())
+    }
+
+    @Test
+    fun errorMessageIfNoUsernameProvided() {
+        stepObjects.allowNotifications()
+        stepObjects.reachSignInScreen()
+        stepObjects.enterUsername(BuildConfig.PIA_VALID_PASSWORD)
+        stepObjects.clickOnLoginButton()
+        assert(SignInPageObjects().noUsernameOrPasswordError.exists())
+    }
+
+
 }

--- a/app/src/androidTest/java/tests/SignInTests.kt
+++ b/app/src/androidTest/java/tests/SignInTests.kt
@@ -1,0 +1,42 @@
+package com.privateinternetaccess.android.tests
+
+import com.privateinternetaccess.android.BuildConfig
+import com.privateinternetaccess.android.core.BaseUiAutomatorClass
+import com.privateinternetaccess.android.screens.objects.MainScreenPageObjects
+import com.privateinternetaccess.android.screens.objects.SignInPageObjects
+import com.privateinternetaccess.android.screens.steps.SignInStepObjects
+import org.junit.Test
+
+class SignInTests : BaseUiAutomatorClass() {
+
+    private val stepObjects = SignInStepObjects()
+
+    @Test
+    fun successfulLoginWithValidCredentials() {
+        stepObjects.allowNotifications()
+        stepObjects.reachSignInScreen()
+        stepObjects.enterUsername(BuildConfig.PIA_VALID_USERNAME)
+        stepObjects.enterPassword(BuildConfig.PIA_VALID_PASSWORD)
+        stepObjects.clickOnLoginButton()
+        stepObjects.allowVpnProfileCreation()
+        assert(MainScreenPageObjects().connectButton.exists())
+    }
+
+    @Test
+    fun incorrectCredentialsReturnToSplashScreen() {
+        stepObjects.allowNotifications()
+        stepObjects.reachSignInScreen()
+        stepObjects.enterUsername("PLACEHOLDER")
+        stepObjects.enterPassword("PLACEHOLDER")
+        stepObjects.clickOnLoginButton()
+        assert(SignInPageObjects().reachLoginScreenButton.exists())
+    }
+
+    @Test
+    fun errorMessageIfNoCredentialsAreProvided() {
+        stepObjects.allowNotifications()
+        stepObjects.reachSignInScreen()
+        stepObjects.clickOnLoginButton()
+        assert(SignInPageObjects().noUsernameOrPasswordError.exists())
+    }
+}

--- a/app/src/androidTest/java/tests/SignInTests.kt
+++ b/app/src/androidTest/java/tests/SignInTests.kt
@@ -15,8 +15,7 @@ class SignInTests : BaseUiAutomatorClass() {
     fun successfulLoginWithValidCredentials() {
         stepObjects.allowNotifications()
         stepObjects.reachSignInScreen()
-        stepObjects.enterUsername(BuildConfig.PIA_VALID_USERNAME)
-        stepObjects.enterPassword(BuildConfig.PIA_VALID_PASSWORD)
+        stepObjects.enterCredentials()
         stepObjects.clickOnLoginButton()
         stepObjects.allowVpnProfileCreation()
         assert(MainScreenPageObjects().connectButton.exists())
@@ -26,8 +25,7 @@ class SignInTests : BaseUiAutomatorClass() {
     fun incorrectCredentialsReturnToSplashScreen() {
         stepObjects.allowNotifications()
         stepObjects.reachSignInScreen()
-        stepObjects.enterUsername(BuildConfig.PIA_INVALID_USERNAME)
-        stepObjects.enterPassword(BuildConfig.PIA_INVALID_PASSWORD)
+        stepObjects.enterCredentials(BuildConfig.PIA_INVALID_USERNAME, BuildConfig.PIA_INVALID_PASSWORD)
         stepObjects.clickOnLoginButton()
         assert(SignInPageObjects().reachLoginScreenButton.exists())
     }
@@ -44,7 +42,7 @@ class SignInTests : BaseUiAutomatorClass() {
     fun errorMessageIfNoPasswordProvided() {
         stepObjects.allowNotifications()
         stepObjects.reachSignInScreen()
-        stepObjects.enterUsername(BuildConfig.PIA_VALID_USERNAME)
+        stepObjects.enterCredentials(BuildConfig.PIA_VALID_USERNAME, "")
         stepObjects.clickOnLoginButton()
         assert(SignInPageObjects().noUsernameOrPasswordError.exists())
     }
@@ -53,7 +51,7 @@ class SignInTests : BaseUiAutomatorClass() {
     fun errorMessageIfNoUsernameProvided() {
         stepObjects.allowNotifications()
         stepObjects.reachSignInScreen()
-        stepObjects.enterUsername(BuildConfig.PIA_VALID_PASSWORD)
+        stepObjects.enterCredentials("", BuildConfig.PIA_VALID_PASSWORD)
         stepObjects.clickOnLoginButton()
         assert(SignInPageObjects().noUsernameOrPasswordError.exists())
     }

--- a/app/src/androidTest/java/tests/SignInTests.kt
+++ b/app/src/androidTest/java/tests/SignInTests.kt
@@ -25,7 +25,10 @@ class SignInTests : BaseUiAutomatorClass() {
     fun incorrectCredentialsReturnToSplashScreen() {
         stepObjects.allowNotifications()
         stepObjects.reachSignInScreen()
-        stepObjects.enterCredentials(BuildConfig.PIA_INVALID_USERNAME, BuildConfig.PIA_INVALID_PASSWORD)
+        stepObjects.enterCredentials(
+            BuildConfig.PIA_INVALID_USERNAME, 
+            BuildConfig.PIA_INVALID_PASSWORD
+        )
         stepObjects.clickOnLoginButton()
         assert(SignInPageObjects().reachLoginScreenButton.exists())
     }


### PR DESCRIPTION
## Summary

We are adding 2 tests cases for sign in 

1. When user has no password provided
2. When user no username provided

The expected results is to provide an error message to the user informing him that he needs both a valid username and password.

We've done some refactoring of `enterCredentials` to facilitate login maintainability.
We've created a constant for `defaultTimeout` period.