### PR TITLE
PIA-649 - Implement method to clear app state after each test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     androidTestImplementation 'com.github.gmazzo:okhttp-mock:1.3.2'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:core:1.4.0'
+    androidTestUtil 'androidx.test:orchestrator:1.4.2'
 
     // EventBus
     implementation 'org.greenrobot:eventbus:3.1.1'
@@ -139,6 +140,7 @@ android {
             useSupportLibrary = true
         }
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunnerArguments clearPackageData: 'true'
     }
 
     sourceSets {
@@ -188,6 +190,7 @@ android {
     }
 
     testOptions { //Used for testing as TextUtils isn't available when testing.
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
         unitTests {
             all {
                 jvmArgs '-noverify'

--- a/app/src/androidTest/java/helpers/ActionHelpers.kt
+++ b/app/src/androidTest/java/helpers/ActionHelpers.kt
@@ -1,12 +1,13 @@
 package com.privateinternetaccess.android.helpers
 
 import androidx.test.uiautomator.UiObject
+import com.privateinternetaccess.android.core.BaseUiAutomatorClass.Companion.defaultTimeOut
 
 object ActionHelpers {
 
     fun clickIfExists(primaryUiObject : UiObject, secondaryUiObj: UiObject? = null) {
         if (primaryUiObject.exists()) {
-            (secondaryUiObj ?: primaryUiObject).click()
+            (secondaryUiObj ?: primaryUiObject).clickAndWaitForNewWindow(defaultTimeOut)
         }
     }
 

--- a/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
+++ b/app/src/androidTest/java/screens/steps/SignInStepObjects.kt
@@ -11,7 +11,7 @@ class SignInStepObjects {
     private val signInPageObjects = SignInPageObjects()
 
     fun allowNotifications() {
-        clickIfExists(signInPageObjects.notificationPrompt, signInPageObjects.allowNotifications)
+        clickIfExists(signInPageObjects.allowNotifications, signInPageObjects.allowNotifications)
     }
 
     fun reachSignInScreen() {


### PR DESCRIPTION
## Jira Ticket
<!--
(Required) If not applicable, state "N/A".
-->
N/A

## Purpose
<!--
(Required) Describe the problem or feature. If background is fully documented in Jira ticket, state "Refer to Jira", otherwise provide a brief summary.
-->
Implemented [Android Test Orchestrator](https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner#enable-gradle) for the Instrumented tests, which allows us to ensure a clean app state after each test through ` testInstrumentationRunnerArguments clearPackageData: 'true'`.

Moreover, some of the helpers and steps used in the Sign In tests have been refactored, by adding a default timeout period and changing the element we interact with, to reduce the flakiness of tests.


## Related PR(s)
<!--
(Optional) Related dependencies to this PR. Use Github lists.
-->
N/A
