### PR TITLE
Remove unused wireguard strings and rename common ones

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/pia/providers/VPNFallbackEndpointProvider.kt
+++ b/app/src/main/java/com/privateinternetaccess/android/pia/providers/VPNFallbackEndpointProvider.kt
@@ -148,7 +148,7 @@ class VPNFallbackEndpointProvider : CoroutineScope {
     private fun updateState(attemptNumber: Int) {
         val stringId = when {
             attemptNumber == 0 -> {
-                R.string.wg_connecting
+                R.string.connecting
             }
             attemptNumber == 1 -> {
                 R.string.please_wait
@@ -157,7 +157,7 @@ class VPNFallbackEndpointProvider : CoroutineScope {
                 R.string.still_connecting
             }
             else -> {
-                R.string.wg_connecting
+                R.string.connecting
             }
         }
 

--- a/app/src/main/java/com/privateinternetaccess/android/ui/views/ConnectionSlider.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/views/ConnectionSlider.java
@@ -140,7 +140,7 @@ public class ConnectionSlider extends FrameLayout implements NetworkConnectionLi
                 EventBus.getDefault().getStickyEvent(VpnStateEvent.class).getLevel();
         switch (status) {
             case LEVEL_CONNECTED:
-                background.setContentDescription(getContext().getString(R.string.wg_connected));
+                background.setContentDescription(getContext().getString(R.string.connected));
                 background.setImageDrawable(
                         getResources().getDrawable(R.drawable.ic_connection_on)
                 );
@@ -164,7 +164,7 @@ public class ConnectionSlider extends FrameLayout implements NetworkConnectionLi
             case LEVEL_START:
             case LEVEL_CONNECTING_NO_SERVER_REPLY_YET:
             case LEVEL_CONNECTING_SERVER_REPLIED:
-                background.setContentDescription(getContext().getString(R.string.wg_connecting));
+                background.setContentDescription(getContext().getString(R.string.connecting));
                 background.setImageDrawable(
                         getResources().getDrawable(R.drawable.ic_connection_connecting)
                 );

--- a/app/src/main/java/com/privateinternetaccess/android/wireguard/backend/GoBackend.java
+++ b/app/src/main/java/com/privateinternetaccess/android/wireguard/backend/GoBackend.java
@@ -360,7 +360,7 @@ public final class GoBackend implements Backend {
             VpnStateEvent event = new VpnStateEvent(
                     "CONNECT",
                     "Wireguard Connect",
-                    R.string.wg_connected,
+                    R.string.connected,
                     ConnectionStatus.LEVEL_CONNECTED
             );
             EventBus.getDefault().postSticky(event);
@@ -553,7 +553,7 @@ public final class GoBackend implements Backend {
         EventBus.getDefault().postSticky(new VpnStateEvent(
                 "CONNECT",
                 "Wireguard Connecting",
-                R.string.wg_connecting,
+                R.string.connecting,
                 ConnectionStatus.LEVEL_CONNECTING_NO_SERVER_REPLY_YET
         ));
 

--- a/app/src/main/res/values-b+ar/strings.xml
+++ b/app/src/main/res/values-b+ar/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">اختيار البروتوكول</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">سيؤدي الانتقال إلى WireGuard إلى تعطيل خاصية الإعدادات لكل تطبيق</string>
-    <string name="wg_protocol_warning">الخصائص التالية غير متوفرة على WireGuard:</string>
-    <string name="wg_connecting">جارٍ الاتصال</string>
-    <string name="wg_connected">متصل بـVPN</string>
+    <string name="connecting">جارٍ الاتصال</string>
+    <string name="connected">متصل بـVPN</string>
     <string name="block_connections_body_1">تتطلب ميزة \"حظر الاتصالات بدون VPN\" من PIA تشغيل VPN الدائم في إعدادات Android.</string>
     <string name="block_connections_body_2">للمتابعة، انتقل إلى الإعدادات - الشبكة والإنترنت - متقدم - VPN - اضغط على أيقونة الإعدادات - قم بتنشيط VPN قيد التشغيل دائمًا.</string>
     <string name="block_connections_button">انتقل إلى إعدادات الشبكة والإنترنت</string>

--- a/app/src/main/res/values-b+da/strings.xml
+++ b/app/src/main/res/values-b+da/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Protokolvalg</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Hvis du skifter til WireGuard, vil Per App-indstillinger-funktionen blive deaktiveret</string>
-    <string name="wg_protocol_warning">Følgende funktioner er ikke tilgængelige på WireGuard:</string>
-    <string name="wg_connecting">Forbinder</string>
-    <string name="wg_connected">VPN forbundet</string>
+    <string name="connecting">Forbinder</string>
+    <string name="connected">VPN forbundet</string>
     <string name="block_connections_body_1">PIA-funktionen \"Bloker forbindelser uden VPN\" kræver, at du tænder for VPN altid til i Android-indstillingerne.</string>
     <string name="block_connections_body_2">For at fortsætte skal du gå til Indstillinger - Netværk og internet - Avanceret - VPN - trykke på ikonet Indstillinger - aktivere VPN altid til.</string>
     <string name="block_connections_button">Gå til Netværks- og internetindstillinger</string>

--- a/app/src/main/res/values-b+de/strings.xml
+++ b/app/src/main/res/values-b+de/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Protokollauswahl</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Wenn du zu WireGuard wechselst, wird die Funktion „Pro App-Einstellungen“ deaktiviert.</string>
-    <string name="wg_protocol_warning">Folgende Funktionen sind bei WireGuard nicht verfügbar:</string>
-    <string name="wg_connecting">Verbindung wird hergestellt</string>
-    <string name="wg_connected">VPN verbunden</string>
+    <string name="connecting">Verbindung wird hergestellt</string>
+    <string name="connected">VPN verbunden</string>
     <string name="block_connections_body_1">Für die PIA-Funktion „Verbindungen ohne VPN blockieren“ muss „VPN immer ein“ in den Android-Einstellungen aktiviert sein.</string>
     <string name="block_connections_body_2">Um fortzufahren, gehe zu Einstellungen - Netzwerk &amp; Internet - Erweitert - VPN - tippe auf das Einstellungen-Symbol - aktiviere „VPN immer ein“.</string>
     <string name="block_connections_button">Netzwerk- &amp; Interneteinstellungen öffnen</string>

--- a/app/src/main/res/values-b+es-rMX/strings.xml
+++ b/app/src/main/res/values-b+es-rMX/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Selección de protocolo</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Si cambia a WireGuard se deshabilitará la función de configuración por aplicación</string>
-    <string name="wg_protocol_warning">Las siguientes funciones no están disponibles en WireGuard:</string>
-    <string name="wg_connecting">Conectando</string>
-    <string name="wg_connected">VPN conectada</string>
+    <string name="connecting">Conectando</string>
+    <string name="connected">VPN conectada</string>
     <string name="block_connections_body_1">La función \"Bloquear conexiones sin VPN\" de PIA requiere ENCENDER VPN siempre ENCENDIDO en la Configuración de Android.</string>
     <string name="block_connections_body_2">Para proceder, vaya a Configuración - Red e Internet - Avanzado - VPN - toque el icono de Configuración - active VPN siempre encendido.</string>
     <string name="block_connections_button">Ir a Configuración de Red e Internet</string>

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Sélection du protocole</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Passer à WireGuard déconnectera la fonctionnalité Paramètres par application</string>
-    <string name="wg_protocol_warning">Les fonctionnalités suivantes ne sont pas disponibles sur WireGuard :</string>
-    <string name="wg_connecting">Connexion</string>
-    <string name="wg_connected">Connecté au VPN</string>
+    <string name="connecting">Connexion</string>
+    <string name="connected">Connecté au VPN</string>
     <string name="block_connections_body_1">La fonctionnalité PIA « Bloquer les connexions sans VPN » requiert l\'ACTIVATION de « VPN toujours ACTIVÉ » dans les paramètres Android.</string>
     <string name="block_connections_body_2">Pour continuer, veuillez accéder à Paramètres - Réseau et Internet - Avancé - VPN - touchez l\'icône Paramètres - Activez « VPN Toujours activé ».</string>
     <string name="block_connections_button">Accéder aux paramètres réseau et Internet</string>

--- a/app/src/main/res/values-b+it/strings.xml
+++ b/app/src/main/res/values-b+it/strings.xml
@@ -526,10 +526,8 @@ privateinternetaccess.com</string>
     <string name="settings_protocol">Selezione del protocollo</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Il passaggio a WireGuard disabiliterà la funzione delle impostazioni per ogni singola app</string>
-    <string name="wg_protocol_warning">Le seguenti funzioni non sono disponibili su WireGuard:</string>
-    <string name="wg_connecting">Connessione in corso</string>
-    <string name="wg_connected">VPN connessa</string>
+    <string name="connecting">Connessione in corso</string>
+    <string name="connected">VPN connessa</string>
     <string name="block_connections_body_1">La funzione \"Blocca connessioni senza VPN\" di PIA richiede l\'attivazione di \"VPN sempre attiva\" nelle impostazioni di Android.</string>
     <string name="block_connections_body_2">Per procedere, vai su Impostazioni - Rete e Internet - Avanzate - VPN - tocca l\'icona Impostazioni - attiva \"VPN sempre attiva\".</string>
     <string name="block_connections_button">Vai a Impostazioni di rete e Internet</string>

--- a/app/src/main/res/values-b+ja/strings.xml
+++ b/app/src/main/res/values-b+ja/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">プロトコル選択</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">WireGuardに切り替えると、アプリ別の設定機能がオフになります。</string>
-    <string name="wg_protocol_warning">WireGuardでは次の機能をご利用いただけます。</string>
-    <string name="wg_connecting">接続中</string>
-    <string name="wg_connected">VPN接続済み</string>
+    <string name="connecting">接続中</string>
+    <string name="connected">VPN接続済み</string>
     <string name="block_connections_body_1">PIAの「VPNなしで接続をブロック」機能を利用するには、Androidの「設定」で「VPNを常にオン」をオンにする必要があります。</string>
     <string name="block_connections_body_2">続行するには、「設定」&gt;「ネットワークとインターネット」&gt;「高度な設定」&gt;「VPN」の順に進み、「設定」アイコンをタップして「VPNを常にオン」を有効にします。</string>
     <string name="block_connections_button">ネットワークとインターネット設定に移動</string>

--- a/app/src/main/res/values-b+ko/strings.xml
+++ b/app/src/main/res/values-b+ko/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">프로토콜 선택</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">WireGuard로 전환하면 앱당 설정 기능이 비활성화됩니다</string>
-    <string name="wg_protocol_warning">다음 기능은 WireGuard에서 사용할 수 없습니다.</string>
-    <string name="wg_connecting">연결 중</string>
-    <string name="wg_connected">VPN 연결됨</string>
+    <string name="connecting">연결 중</string>
+    <string name="connected">VPN 연결됨</string>
     <string name="block_connections_body_1">PIA의 \"VPN 없는 연결 차단\" 기능을 사용하려면 Android 설정에서 \'VPN 항상 켜기\'를 활성화해야 합니다.</string>
     <string name="block_connections_body_2">계속하려면 설정 - 네트워크 및 인터넷 - 고급 - VPN - 설정 아이콘 탭하기 - \'VPN 항상 켜기\' 활성화의 순서로 작업합니다.</string>
     <string name="block_connections_button">네트워크 및 인터넷 설정으로 이동</string>

--- a/app/src/main/res/values-b+nb/strings.xml
+++ b/app/src/main/res/values-b+nb/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Protokollvalg</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Bytte til WireGuard deaktiverer funksjonen per appinnstillinger</string>
-    <string name="wg_protocol_warning">Følgende funksjoner er ikke tilgjengelige på WireGuard:</string>
-    <string name="wg_connecting">Kobler til</string>
-    <string name="wg_connected">VPN-tilkoblet</string>
+    <string name="connecting">Kobler til</string>
+    <string name="connected">VPN-tilkoblet</string>
     <string name="block_connections_body_1">PIA-funksjonen «Blokker tilkoblinger uten VPN» krever at du slår PÅ Alltid VPN PÅ i Android-innstillingene.</string>
     <string name="block_connections_body_2">For å fortsette, gå til Innstillinger – Nettverk og Internett – Avansert – VPN – trykk på Innstillinger-ikonet – aktiver Alltid VPN PÅ.</string>
     <string name="block_connections_button">Gå til Nettverks- og Internettinnstillinger</string>

--- a/app/src/main/res/values-b+nl/strings.xml
+++ b/app/src/main/res/values-b+nl/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Protocolselectie</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Als u naar WireGuard overschakelt, wordt de functie \'Per app-instellingen\' uitgeschakeld.</string>
-    <string name="wg_protocol_warning">De volgende functies zijn niet beschikbaar op WireGuard:</string>
-    <string name="wg_connecting">Verbinden</string>
-    <string name="wg_connected">VPN verbonden</string>
+    <string name="connecting">Verbinden</string>
+    <string name="connected">VPN verbonden</string>
     <string name="block_connections_body_1">Voor de functie \'Verbindingen zonder VPN blokkeren\' moet de optie VPN altijd aan op AAN worden gezet in de Android-instellingen.</string>
     <string name="block_connections_body_2">Wilt u doorgaan, ga dan naar Instellingen - Netwerk en internet - Geavanceerd - VPN - tik op het Instellingen-pictogram - activeer VPN altijd aan.</string>
     <string name="block_connections_button">Naar Netwerk en internetinstellingen</string>

--- a/app/src/main/res/values-b+pl/strings.xml
+++ b/app/src/main/res/values-b+pl/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Wybór protokołu</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Przełączenie na WireGuard wyłączy funkcję Ustawienia aplikacji</string>
-    <string name="wg_protocol_warning">Następujące funkcje nie są dostępne w WireGuard:</string>
-    <string name="wg_connecting">Łączenie</string>
-    <string name="wg_connected">Połączono z VPN</string>
+    <string name="connecting">Łączenie</string>
+    <string name="connected">Połączono z VPN</string>
     <string name="block_connections_body_1">Funkcja PIA „Blokuj połączenia bez VPN” wymaga włączenia Zawsze przez VPN w ustawieniach Androida.</string>
     <string name="block_connections_body_2">Aby kontynuować, przejdź do Ustawienia - Sieć i Internet - Zaawansowane - VPN - dotknij ikony Ustawienia - aktywuj Zawsze przez VPN.</string>
     <string name="block_connections_button">Przejdź do ustawień sieci i internetu</string>

--- a/app/src/main/res/values-b+pt-rBR/strings.xml
+++ b/app/src/main/res/values-b+pt-rBR/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Seleção de protocolo</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Trocar para WireGuard irá desabilitar o recurso de Configurações por Aplicativo</string>
-    <string name="wg_protocol_warning">Os seguintes recursos não estão disponíveis no WireGuard:</string>
-    <string name="wg_connecting">Conectando</string>
-    <string name="wg_connected">VPN Conectada</string>
+    <string name="connecting">Conectando</string>
+    <string name="connected">VPN Conectada</string>
     <string name="block_connections_body_1">O recurso \"Bloquear conexões sem VPN\" do PIA exige que você ativer a opção \"VPN sempre ativa\" nas configurações do Android.</string>
     <string name="block_connections_body_2">Para continuar, vá até Configurações - Rede e Internet - Avançado - VPN - toque no ícone de Configurações - ative a opção \"VPN sempre ativa\".</string>
     <string name="block_connections_button">Vá até Configurações de rede e internet</string>

--- a/app/src/main/res/values-b+ru/strings.xml
+++ b/app/src/main/res/values-b+ru/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Выбор протокола</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Переключение на WireGuard отключит функцию «Настройки по каждому приложению»</string>
-    <string name="wg_protocol_warning">Следующие функции недоступны в WireGuard:</string>
-    <string name="wg_connecting">Идет подключение</string>
-    <string name="wg_connected">VPN подключен</string>
+    <string name="connecting">Идет подключение</string>
+    <string name="connected">VPN подключен</string>
     <string name="block_connections_body_1">Функция PIA «Блокировать соединения без VPN» требует включения Always-ON VPN в настройках Android.</string>
     <string name="block_connections_body_2">Чтобы продолжить, перейдите в «Настройки» - «Сеть и Интернет» - «Дополнительно» - «VPN» - нажмите на значок «Настройки» - активируйте «Always-on VPN».</string>
     <string name="block_connections_button">Перейдите в «Настройки» - «Сеть и Интернет».</string>

--- a/app/src/main/res/values-b+th/strings.xml
+++ b/app/src/main/res/values-b+th/strings.xml
@@ -527,10 +527,8 @@
     <string name="settings_protocol">การเลือกโปรโตคอล</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">การเปลี่ยนเป็น WireGuard จะปิดใช้งานคุณสมบัติการตั้งค่าแอปรายตัว</string>
-    <string name="wg_protocol_warning">คุณสมบัติต่อไปนี้ไม่สามารถใช้ได้ใน WireGuard:</string>
-    <string name="wg_connecting">กำลังเชื่อมต่อ</string>
-    <string name="wg_connected">เชื่อมต่อ VPN แล้ว</string>
+    <string name="connecting">กำลังเชื่อมต่อ</string>
+    <string name="connected">เชื่อมต่อ VPN แล้ว</string>
     <string name="block_connections_body_1">คุณสมบัติ \"บล็อกการเชื่อมต่อที่ไม่มี VPN\" ของ PIA ต้องให้เปิด \"เปิด VPN เสมอ\" ในการตั้งค่า Android</string>
     <string name="block_connections_body_2">ในการดำเนินการต่อ ให้ไปยัง การตั้งค่า - เครือข่ายและอินเทอร์เน็ต - ขั้นสูง - VPN - แตะที่ไอคอนการตั้งค่า - เปิด \"เปิด VPN เสมอ\"</string>
     <string name="block_connections_button">ไปยังการตั้งค่าเครือข่ายและอินเทอร์เน็ต</string>

--- a/app/src/main/res/values-b+tr/strings.xml
+++ b/app/src/main/res/values-b+tr/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">Protokol Seçimi</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">WireGuard\'a geçmek Tek Uygulama Ayarları özelliğini devreden çıkarır</string>
-    <string name="wg_protocol_warning">Şu özellikler WireGuard\'da  mevcut değildir:</string>
-    <string name="wg_connecting">Bağlanılıyor</string>
-    <string name="wg_connected">VPN Bağlandı</string>
+    <string name="connecting">Bağlanılıyor</string>
+    <string name="connected">VPN Bağlandı</string>
     <string name="block_connections_body_1">PIA \"VPN’siz bağlantıları engelle\" özelliği, Android Ayarlarından Her Zaman VPN AÇIK özelliğinin açılmasını gerektiriyor.</string>
     <string name="block_connections_body_2">Devam etmek için Ayarlar - Ağ ve İnternet - Gelişmiş - VPN - bölümüne gidin Ayarlar simgesine dokunun - VPN her Zaman Açık özelliğini etkinleştirin.</string>
     <string name="block_connections_button">Ağ ve İnternet Ayarlarına gidin</string>

--- a/app/src/main/res/values-b+zh-rCN/strings.xml
+++ b/app/src/main/res/values-b+zh-rCN/strings.xml
@@ -525,10 +525,8 @@
     <string name="settings_protocol">协议选择</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">切换到 WireGuard 将禁用“按应用程序设置”功能</string>
-    <string name="wg_protocol_warning">以下功能将在 WireGuard 上失效：</string>
-    <string name="wg_connecting">正在连接</string>
-    <string name="wg_connected">VPN 已连接</string>
+    <string name="connecting">正在连接</string>
+    <string name="connected">VPN 已连接</string>
     <string name="block_connections_body_1">PIA 的“阻止未使用 VPN 时的连接”功能需要在 Android 设置中打开“永远在线 VPN”。</string>
     <string name="block_connections_body_2">要继续操作，请进入设置 - 网络和互联网 - 高级 - VPN - 点击设置图标 - 激活永远在线 VPN。</string>
     <string name="block_connections_button">进入网络和互联网设置</string>

--- a/app/src/main/res/values-b+zh-rTW/strings.xml
+++ b/app/src/main/res/values-b+zh-rTW/strings.xml
@@ -527,10 +527,8 @@
     <string name="settings_protocol">選擇通訊協定</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">切換至 WireGuard 將停用按應用程式而定的設定功能</string>
-    <string name="wg_protocol_warning">以下功能不適用於 WireGuard：</string>
-    <string name="wg_connecting">連線中</string>
-    <string name="wg_connected">已連接 VPN</string>
+    <string name="connecting">連線中</string>
+    <string name="connected">已連接 VPN</string>
     <string name="block_connections_body_1">PIA「封鎖未使用 VPN 的連線」功能需要在 Android 設定中啟用「總是啟用 VPN」。</string>
     <string name="block_connections_body_2">如要繼續，請前往「設定」-「網路和網際網路」-「進階」-「VPN」- 點擊「設定」圖示 - 啟動「總是啟用 VPN」。</string>
     <string name="block_connections_button">前往「網路和網際網路」設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,9 @@
     <string name="full_licenses">Full licenses</string>
     <string name="email">Email</string>
     <string name="please_wait">Please wait</string>
+    <string name="connecting">Connecting</string>
     <string name="still_connecting">Still trying to connect</string>
+    <string name="connected">VPN Connected</string>
     <string name="enabled">Enabled</string>
     <string name="disabled">Disabled</string>
     <string name="account_details_password_bottom_text">Tap \"eye\" to reveal. Tap again to copy Password to clipboard.</string>
@@ -544,10 +546,6 @@
     <string name="settings_protocol">Protocol Selection</string>
     <string name="protocol_ovpn">OpenVPN</string>
     <string name="protocol_wireguard">WireGuard</string>
-    <string name="wg_per_app_warning">Switching to WireGuard will disable the Per App Settings-feature</string>
-    <string name="wg_protocol_warning">The following features are not available on WireGuard:</string>
-    <string name="wg_connecting">Connecting</string>
-    <string name="wg_connected">VPN Connected</string>
     <string name="block_connections_body_1">The PIA \"Block connections without VPN\" feature requires turning ON the Always-ON VPN in the Android Settings.</string>
     <string name="block_connections_body_2">To proceed, go to Settings - Network &amp; Internet - Advanced - VPN - tap on the Settings icon - activate Always-on VPN.</string>
     <string name="block_connections_button">Go to Network &amp; Internet Settings</string>


### PR DESCRIPTION
## Summary

As per title. We are removing a couple of unused wireguard strings and renaming common ones so that they are not misleading.

## Sanity Tests

- [x] Tap to connect. Confirm we show the string "Connecting".
- [x] Once connected. Confirm we show "Connected to VPN".