### PR TITLE
PIA-638: Add new tests for protocols with small packets enable and disable

### DIFF
--- a/app/src/androidTest/java/screens/objects/ProtocolPageObjects.kt
+++ b/app/src/androidTest/java/screens/objects/ProtocolPageObjects.kt
@@ -9,5 +9,6 @@ class ProtocolPageObjects {
     val protocolSummarySetting = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/protocolSummarySetting")
     val openVPN = LocatorHelper.findByText("OpenVPN")
     val wireGuard = LocatorHelper.findByText("WireGuard")
+    val smallPacketsSwitchSetting = LocatorHelper.findByResourceId("com.privateinternetaccess.android:id/smallPacketsSwitchSetting")
     val save = LocatorHelper.findByResourceId("android:id/button1")
 }

--- a/app/src/androidTest/java/tests/ProtocolConnectivityTests.kt
+++ b/app/src/androidTest/java/tests/ProtocolConnectivityTests.kt
@@ -16,8 +16,12 @@ class ProtocolConnectivityTests : BaseUiAutomatorClass() {
     val protocolStepObjects = ProtocolStepObjects()
     val mainScreenStepObjects = MainScreenStepObjects()
 
+    /* OpenVPN protocol by default has small packets option disabled.
+    (i) First test scenario is to validate that OpenVPN can connect while small packet is disabled
+    (ii) Second test is to validate that OpenVPN can connect while small packet is enabled.
+     */
     @Test
-    fun openVPNConnectivity() {
+    fun openVPNConnectivityWhenSmallPacketDisabled() {
         successfulLogin()
         goToSettings(protocolPageObjects.protocolSettings, protocolPageObjects.protocolSelection)
         protocolStepObjects.selectOpenVPN()
@@ -27,7 +31,33 @@ class ProtocolConnectivityTests : BaseUiAutomatorClass() {
     }
 
     @Test
-    fun wireGuardConnectivity() {
+    fun openVPNConnectivityWhenSmallPacketEnabled() {
+        successfulLogin()
+        goToSettings(protocolPageObjects.protocolSettings, protocolPageObjects.protocolSelection)
+        protocolStepObjects.selectOpenVPN()
+        protocolPageObjects.smallPacketsSwitchSetting.click()
+        returnOnMainScreen()
+        mainScreenStepObjects.clickConnect()
+        assert(MainScreenPageObjects().connectButton.contentDescription.equals("VPN Connected"))
+    }
+
+    /* WireGuard protocol by default has small packets enabled.
+    (i) First test scenario is to validate that WireGuard can connect while small packet is disabled.
+    (ii) Second test is to validate that WireGuard can connect while small packet is enabled.
+     */
+    @Test
+    fun wireGuardConnectivityWhenSmallPacketDisabled() {
+        successfulLogin()
+        goToSettings(protocolPageObjects.protocolSettings, protocolPageObjects.protocolSelection)
+        protocolStepObjects.selectWireGuard()
+        protocolPageObjects.smallPacketsSwitchSetting.click()
+        returnOnMainScreen()
+        mainScreenStepObjects.clickConnect()
+        assert(MainScreenPageObjects().connectButton.contentDescription.equals("VPN Connected"))
+    }
+
+    @Test
+    fun wireGuardConnectivityWhenSmallPacketEnabled() {
         successfulLogin()
         goToSettings(protocolPageObjects.protocolSettings, protocolPageObjects.protocolSelection)
         protocolStepObjects.selectWireGuard()


### PR DESCRIPTION
## Purpose

The initial test for this was to test the connectivity of OpenVPN while small packet settings is disabled and WireGuard small packet settings is enabled. We want to extend the coverage of our tests to make sure that for the two available protocols there is no issue connecting with the VPN whether small packet is enabled or disabled.