### PR TITLE
PIA-936: Fix wrong login screen on amazon firestick

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/PIAApplication.java
+++ b/app/src/main/java/com/privateinternetaccess/android/PIAApplication.java
@@ -324,7 +324,7 @@ public class PIAApplication extends Application {
     public static boolean isAmazon(){
         String brand = Build.BRAND;
         DLog.d("isAmazon"," " + Build.MODEL + " " + Build.DEVICE + " " + Build.BRAND + " " + Build.PRODUCT + " " + Build.BOARD);
-        if(!TextUtils.isEmpty(brand))
+        if(!TextUtils.isEmpty(brand) && BuildConfig.FLAVOR_store.equals("amazonstore"))
             return brand.toLowerCase().contains("amazon");
         else
             return false;


### PR DESCRIPTION
## Summary

We have currently an issue where the Firestick is showing the subscription login screen due to the condition validating only for the device's Amazon brand and not buildconfig.

## Sanity Tests

- [x] Open the application using a firestick. Confirm proper login screen.