### PR TITLE
Bump version name and code to 3.24.0 and 592 respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 591
-        versionName "3.23.0"
+        versionCode 592
+        versionName "3.24.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.24.0` and its code to `592`.

## Sanity Tests

N/A