### PR TITLE
PIA-973: Skip GetStarted screen on amazon branded devices

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/PIAApplication.java
+++ b/app/src/main/java/com/privateinternetaccess/android/PIAApplication.java
@@ -320,13 +320,17 @@ public class PIAApplication extends Application {
      *
      * @return if Build.BRAND == amazon
      */
-    public static boolean isAmazon(){
+    public static boolean isAmazon() {
+        return isAmazonBrand() && isAmazonFlavour();
+    }
+
+    public static boolean isAmazonBrand() {
         String brand = Build.BRAND;
-        DLog.d("isAmazon"," " + Build.MODEL + " " + Build.DEVICE + " " + Build.BRAND + " " + Build.PRODUCT + " " + Build.BOARD);
-        if(!TextUtils.isEmpty(brand) && BuildConfig.FLAVOR_store.equals("amazonstore"))
-            return brand.toLowerCase().contains("amazon");
-        else
-            return false;
+        return !TextUtils.isEmpty(brand) && brand.toLowerCase().contains("amazon");
+    }
+
+    public static boolean isAmazonFlavour() {
+        return BuildConfig.FLAVOR_store.equals("amazonstore");
     }
 
     public static boolean isChromebook(Context context){

--- a/app/src/main/java/com/privateinternetaccess/android/ui/loginpurchasing/LoginPurchaseActivity.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/loginpurchasing/LoginPurchaseActivity.java
@@ -194,7 +194,11 @@ public class LoginPurchaseActivity extends BaseActivity {
                     && !BuildConfig.FLAVOR_store.equals("noinapp")) {
                 frag = new NewGetStartedFragment();
             } else {
-                frag = new GetStartedFragment();
+                if (PIAApplication.isAmazonBrand()) {
+                    frag = new LoginFragment();
+                } else {
+                    frag = new GetStartedFragment();
+                }
             }
             FragmentTransaction trans = getSupportFragmentManager().beginTransaction();
             trans.replace(R.id.container, frag);


### PR DESCRIPTION
## Summary

As per title. On Amazon-branded devices, we want to jump directly to the login screen as we can't offer subscriptions in that environment.

## Sanity Tests

- [x] Install on Fire TV. Open application. Confirm we are presented with the Login screen.
- [x] After the above. Login. Logout. Confirm we go back to the Login screen.