### PR TITLE
PIA-955: Show the per-app settings option on Android TV for both protocols

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/ui/tv/fragments/PanelFragment.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/tv/fragments/PanelFragment.java
@@ -107,12 +107,5 @@ public class PanelFragment extends Fragment {
     public void onResume() {
         super.onResume();
         portWidget.updateState();
-
-        if (VPNProtocol.activeProtocol(getContext()) == VPNProtocol.Protocol.OpenVPN) {
-            perAppSettingsPanelItem.setVisibility(View.VISIBLE);
-        }
-        else {
-            perAppSettingsPanelItem.setVisibility(View.GONE);
-        }
     }
 }


### PR DESCRIPTION
## Summary

As per title. We are now showing the per-app settings option for both VPN protocols. 

## Sanity Tests

- [x] Open App. Confirm the option present for OpenVPN.
- [x] After the above. Change to Wireguard. Confirm the option present for Wireguard.
- [x] After the above. Connect to any region. Go to PIA's what-is-my-ip website. Confirm it shows protected.
- [x] After the above. Disconnect. Go to per-app settings and uncheck the browser. Connect to any region. Go to PIA's what-is-my-ip website. Confirm it shows unprotected.