### PR TITLE
PIA-978: Update accounts library to version 1.4.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation project(":core")
 
     // Commons
-    implementation("com.kape.android:account-android:1.4.5")
+    implementation("com.kape.android:account-android:1.4.6")
     implementation("com.kape.android:regions-android:1.6.2")
     implementation("com.kape.android:csi-android:1.3.2")
     implementation("com.kape.android:kpi-android:1.2.2")


### PR DESCRIPTION
## Summary

As per title. It updates our account dependency to version `1.4.6`.

## Sanity Tests

- [x] Open the app. Login. Confirm we log in successfully.
- [x] After the above. Connect to any region. Confirm we connect successfully.
- [x] After the above. Logout. Confirm we log out successfully.