### PR TITLE
PIA-953: Fix system dns resolver not being selectable on tv

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/ui/drawer/settings/SettingsSectionNetworkFragment.kt
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/drawer/settings/SettingsSectionNetworkFragment.kt
@@ -184,7 +184,13 @@ class SettingsSectionNetworkFragment : Fragment() {
         val builder = AlertDialog.Builder(context)
         builder.setTitle(R.string.dns_pref_header)
         builder.setCancelable(false)
-        builder.setAdapter(adapter, selectionCallback)
+        builder.setSingleChoiceItems(
+            adapter,
+            adapter.selectedIndex
+        ) { _, which ->
+            adapter.selected = options[which]
+            adapter.notifyDataSetChanged()
+        }
         builder.setPositiveButton(R.string.save, selectionCallback)
 
         // If there is more than the default option

--- a/app/src/main/java/com/privateinternetaccess/android/ui/drawer/settings/SettingsSectionProtocolFragment.kt
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/drawer/settings/SettingsSectionProtocolFragment.kt
@@ -172,7 +172,8 @@ class SettingsSectionProtocolFragment : Fragment() {
         val builder = AlertDialog.Builder(context)
         builder.setTitle(R.string.settings_protocol)
         builder.setSingleChoiceItems(
-            adapter, protocols.indexOf(PiaPrefHandler.getProtocol(requireContext()))
+            adapter,
+            protocols.indexOf(PiaPrefHandler.getProtocol(requireContext()))
         ) { _, which ->
             adapter.selected = protocols[which]
             adapter.notifyDataSetChanged()
@@ -207,7 +208,8 @@ class SettingsSectionProtocolFragment : Fragment() {
         builder.setTitle(R.string.transport)
         builder.setCancelable(true)
         builder.setSingleChoiceItems(
-            adapter, protocolTransportList.indexOf(PiaPrefHandler.getProtocol(requireContext()))
+            adapter,
+            protocolTransportList.indexOf(PiaPrefHandler.getProtocol(requireContext()))
         ) { _, which ->
             adapter.selected = protocolTransportList[which]
             adapter.notifyDataSetChanged()
@@ -240,7 +242,8 @@ class SettingsSectionProtocolFragment : Fragment() {
         builder.setTitle(R.string.data_encyrption)
         builder.setCancelable(true)
         builder.setSingleChoiceItems(
-            adapter, values.indexOf(PiaPrefHandler.getDataCipher(context))
+            adapter,
+            values.indexOf(PiaPrefHandler.getDataCipher(context))
         ) { _, which ->
             adapter.selected = values[which]
             adapter.notifyDataSetChanged()
@@ -283,7 +286,8 @@ class SettingsSectionProtocolFragment : Fragment() {
         builder.setTitle(R.string.remote_port)
         builder.setCancelable(true)
         builder.setSingleChoiceItems(
-            adapter, options.indexOf(PiaPrefHandler.getRemotePort(context))
+            adapter,
+            options.indexOf(PiaPrefHandler.getRemotePort(context))
         ) { _, which ->
             adapter.selected = options[which]
             adapter.notifyDataSetChanged()


### PR DESCRIPTION
## Summary

Update the System DNS dialog to use `setSingleChoiceItems` as per the other similar settings and make sure to invoke `notifyDataSetChanged` on selection to propagate the state.

## Sanity Test

- [x] On Android TV. Login. Navigate to the option. Confirm I can select the different options successfully.
- [x] On Mobile. Login. Navigate to the option. Confirm I can select the different options successfully.