### PR TITLE
Bump version name and code to `3.26.0` and `595` respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 593
-        versionName "3.25.0"
+        versionCode 595
+        versionName "3.26.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.26.0` and its code to `595`.

## Sanity Tests

N/A