### PR TITLE
Bump version name and code to `3.27.0` and `596` respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 595
-        versionName "3.26.0"
+        versionCode 596
+        versionName "3.27.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.27.0` and its code to `596`.

## Sanity Tests

N/A