### PR TITLE
Bump version name and code to `3.28.0` and `597` respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 596
-        versionName "3.27.0"
+        versionCode 597
+        versionName "3.28.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.28.0` and its code to `597`.

## Sanity Tests

N/A