### PR TITLE
PIA-1218: Update regions library to version `1.6.4`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     // Commons
     implementation("com.kape.android:account-android:1.4.6")
-    implementation("com.kape.android:regions-android:1.6.2")
+    implementation("com.kape.android:regions-android:1.6.4")
     implementation("com.kape.android:csi-android:1.3.2")
     implementation("com.kape.android:kpi-android:1.2.2")
 


### PR DESCRIPTION
## Summary

As per title. It updates the regions library to version `1.6.4`.

## Sanity Tests

- [x] Login. Go to regions list. Pull down to refresh. Confirm it succeeds and updates latencies.