### PR TITLE
Bump version name and code to `3.29.0` and `598` respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 597
-        versionName "3.28.0"
+        versionCode 598
+        versionName "3.29.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.29.0` and its code to `598`.

## Sanity Tests

- [x] Go through the charter. Confirm everything works as expected.