### PR TITLE
PIA-1239: Bump version name and code to `3.30.0` and `599` respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 598
-        versionName "3.29.0"
+        versionCode 599
+        versionName "3.30.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.30.0` and its code to `599`.

## Sanity Tests

- [x] Go through the charter. Confirm everything works as expected.