### PR TITLE
PIA-1290: Fix issue where the login screen was presented start on a cold start

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/ui/superclasses/BaseActivity.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/superclasses/BaseActivity.java
@@ -683,6 +683,9 @@ public abstract class BaseActivity extends SwipeBackBaseActivity implements Netw
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onExpiredApiTokenEvent(ExpiredApiTokenEvent event) {
-        navigateToLogin();
+        IAccount account = PIAFactory.getInstance().getAccount(this);
+        if (account.loggedIn()) {
+            navigateToLogin();
+        }
     }
 }


### PR DESCRIPTION
## Summary

It fixes an issue where the login screen was being presented twice when opening the application while logged out. This is due to the logic updating tokens failing (no known token). This failure is handled as a 401 by the API, which in turn triggers the logic to logout the user, presenting it with the login screen. All that logic is valid, which means I'm just validating that we navigate to the login screen if we are logged in.

## Sanity Tests

- [x] Install the app. Open the application. Confirm we are not presented with the login screen twice.

