### PR TITLE
PIA-1323: Bump version name and code to `3.31.0` and `601` respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 599
-        versionName "3.30.0"
+        versionCode 601
+        versionName "3.31.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.31.0` and its code to `601`.

## Sanity Tests

- [x] Go through the charter. Confirm everything works as expected.