### PR TITLE
PIA-1290: Fix illegal state exception on signup flow

### DIFF
--- a/app/src/main/java/com/privateinternetaccess/android/ui/loginpurchasing/LoginPurchaseActivity.java
+++ b/app/src/main/java/com/privateinternetaccess/android/ui/loginpurchasing/LoginPurchaseActivity.java
@@ -258,7 +258,7 @@ public class LoginPurchaseActivity extends BaseActivity {
             frag.setFireOffPurchasing(fireOffPurchasing);
             frag.setTrial(isTrial);
             frag.setLoginWithReceipt(isLoginWithReceipt);
-            getSupportFragmentManager().beginTransaction().replace(R.id.container, frag).commit();
+            getSupportFragmentManager().beginTransaction().replace(R.id.container, frag).commitAllowingStateLoss();
         });
     }
 


### PR DESCRIPTION
## Summary

It allows for the loss of state on the login screen as otherwise an exception would be thrown on edge cases, where we are trying to commit the transaction after a state saved has occurred. Given that we are not interested in saving the state of the login screen, let it be dropped instead of crashing.

## Sanity Tests

- [x] Open the application. Subscribe. Confirm we don't crash. Repeat multiple times.