### PR TITLE
PIA-1361: Fix margin issue in the email purchase fragment

### DIFF
--- a/app/src/main/res/layout/fragment_purchase_process.xml
+++ b/app/src/main/res/layout/fragment_purchase_process.xml
@@ -40,6 +40,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="3dp"
+            android:paddingHorizontal="16dp"
             android:background="@color/windowBackground">
 
             <androidx.appcompat.widget.AppCompatImageView
@@ -47,8 +48,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="25dp"
-                android:layout_marginLeft="25dp"
-                android:layout_marginRight="25dp"
+                android:layout_marginHorizontal="9dp"
                 android:scaleType="centerInside"
                 app:srcCompat="@drawable/ic_pia_logo"/>
 
@@ -82,8 +82,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="25dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
                 app:hint="@string/email_address"
                 app:textColorMain="?attr/piax_edit_text_color"
                 app:underlineColor="?attr/piax_edit_underline_color"
@@ -93,8 +91,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
                 android:layout_marginTop="15dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
                 style="@style/PiaxGreenButton"
                 android:text="@string/submit"
                 android:id="@+id/fragment_purchasing_email_submit"


### PR DESCRIPTION
## Summary

It fixes the issue by moving the margin as padding of the container, rather than defining it on each element.

## Sanity Tests

- [x] Navigate to the affected fragment. Confirm the margin is applied to all elements.