### PR TITLE
PIA-1362: Bump version name and code to `3.32.0` and `602` respectively

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         renderscriptTargetApi rootProject.minSdkVersion
         renderscriptSupportModeEnabled true
 
-        versionCode 601
-        versionName "3.31.0"
+        versionCode 602
+        versionName "3.32.0"
 
         setProperty("archivesBaseName", "pia-$versionName-$versionCode")
         vectorDrawables {


### PR DESCRIPTION
## Summary

As per title. It updates the version name to `3.32.0` and its code to `602`.

## Sanity Tests

- [x] Go through the charter. Confirm everything works as expected.